### PR TITLE
MOD-691 Latest Internet Identity fails in local Chrome

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -111,8 +111,8 @@
     },
     "internet_identity": {
       "type": "custom",
-      "candid": "https://github.com/dfinity/internet-identity/releases/download/release-2023-11-17/internet_identity.did",
-      "wasm": "https://github.com/dfinity/internet-identity/releases/download/release-2023-11-17/internet_identity_dev.wasm.gz",
+      "candid": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity.did",
+      "wasm": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm.gz",
       "remote": {
         "id": {
           "ic": "rwlgt-iiaaa-aaaaa-aaaaa-cai"

--- a/src/modclub_assets/src/contexts/auth.tsx
+++ b/src/modclub_assets/src/contexts/auth.tsx
@@ -3,6 +3,7 @@ import { Identity } from "@dfinity/agent";
 import type { IDL } from "@dfinity/candid";
 import { modclub, rs, vesting, wallet, airdrop } from "../actors_by_env";
 import canisterIds from "../../../../canister_ids.json";
+import { detectBrowser } from "../utils/util";
 
 /*
  * Connect2ic provides essential utilities for IC app development
@@ -37,7 +38,13 @@ function deepCopy(obj) {
 
 const providers_cb = (config) => {
   const II_config = deepCopy(config);
-  II_config["providerUrl"] = process.env.LOCAL_II_CANISTER;
+  const browser = detectBrowser();
+  if (browser === 'Safari') {
+    II_config["providerUrl"] = process.env.LOCAL_II_CANISTER_SAFARI;
+  } else {
+    II_config["providerUrl"] = process.env.LOCAL_II_CANISTER;
+  }
+  
   II_config["ii_auth_config"] = {
     idleOptions: {
       disableIdle: true,

--- a/src/modclub_assets/src/utils/util.ts
+++ b/src/modclub_assets/src/utils/util.ts
@@ -208,3 +208,20 @@ export const formattedTime = (val) => {
   time.setSeconds(val);
   return format(time, "mm:ss");
 };
+
+type BrowserType = "Chrome" | "Safari" | "Other";
+export function detectBrowser(): BrowserType {
+    const userAgent: string = navigator.userAgent;
+
+    // Check if browser is Chrome
+    if (userAgent.match(/chrome|chromium|crios/i)) {
+        return "Chrome";
+    }
+    // Check if browser is Safari
+    else if (userAgent.match(/safari/i) && !userAgent.match(/chrome|chromium|crios/i)) {
+        return "Safari";
+    }
+    else {
+        return "Other";
+    }
+}

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -45,16 +45,24 @@ function getCurrentTimestamp() {
   return `${year}-${month}-${day}-${hour}.${minute}`;
 }
 
+
+// See readme of https://github.com/dfinity/internet-identity.
+// For some reason, we need different urls for different browsers.
 let LOCAL_II_CANISTER = "";
+let LOCAL_II_CANISTER_SAFARI = "";
 try {
-  // Replace this value with the ID of your local Internet Identity canister
+  LOCAL_II_CANISTER_SAFARI = network === "local"
+    ? `http://localhost:8000/?canisterId=${process.env["INTERNET_IDENTITY_CANISTER_ID"]}`
+    : `https://identity.ic0.app`;
   LOCAL_II_CANISTER =
     network === "local"
-      ? `http://localhost:8000/?canisterId=${process.env["INTERNET_IDENTITY_CANISTER_ID"]}`
+      ? `http://${process.env["INTERNET_IDENTITY_CANISTER_ID"]}.localhost:8000`
       : `https://identity.ic0.app`;
 } catch (e) {
   console.error("Error setting LOCAL_II_CANISTER: ", e);
   LOCAL_II_CANISTER =
+    "http://localhost:8000/?canisterId=rwlgt-iiaaa-aaaaa-aaaaa-cai";
+  LOCAL_II_CANISTER_SAFARI = 
     "http://localhost:8000/?canisterId=rwlgt-iiaaa-aaaaa-aaaaa-cai";
 }
 const isDevelopment = process.env.NODE_ENV !== "production";
@@ -157,6 +165,7 @@ module.exports = {
       AIRDROP_DEV_CANISTER_ID: canisters["airdrop_dev"] || "aaaaa-aa",
       AIRDROP_QA_CANISTER_ID: canisters["airdrop_qa"] || "aaaaa-aa",
       LOCAL_II_CANISTER,
+      LOCAL_II_CANISTER_SAFARI,
       DFX_NETWORK: process.env.DFX_NETWORK || "local",
       DEV_ENV: process.env.DEV_ENV || "production",
       DEPLOYMENT_TAG:


### PR DESCRIPTION
---
### Summary
As per readme in https://github.com/dfinity/internet-identity:
>To access Internet Identity or configure it for your dapp, use one of the following URLs:
Chrome, Firefox: http://<canister_id>.localhost:4943
Safari: http://localhost:4943?canisterId=<canister_id>

See https://github.com/dfinity/internet-identity/pull/2147 for details.

### Issues
[*Link to the issue
](https://linear.app/modclub/issue/MOD-691/latest-internet-identity-fails-in-chrome-and-brave)

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

### Checklist
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published.

### Test
Local test sign-in in Chrome.
### Additional Context
*Add any other context or screenshots about the pull request