### PR TITLE
MOD-697 Backup process preventing deployment of prod

### DIFF
--- a/.github/workflows/create_proposal.yml
+++ b/.github/workflows/create_proposal.yml
@@ -133,6 +133,7 @@ jobs:
           ENVIRONMENT: ${{ github.event.inputs.ENVIRONMENT }}
 
       - name: Backup - before deployment
+        if: ${{ github.event.inputs.CANISTER == 'modclub' }}
         run: |
           if ! ./scripts/deployment/gh_backup.sh; then
             echo "Backup failed"

--- a/scripts/backup/backup_util.sh
+++ b/scripts/backup/backup_util.sh
@@ -3,8 +3,10 @@ backup_modclub() {
     local data_label=$1
     local tag=$2
     local network=$3
+    local env=$4
 
-    backupOutput=$(dfx canister call modclub_qa backup "(\"$data_label\", \"$tag\")" --network=$network)
+    modclub=$(get_canister_name_by_env $env "modclub")
+    backupOutput=$(dfx canister call $modclub backup "(\"$data_label\", \"$tag\")" --network=$network)
     
     pattern='^\([0-9]+ : nat\)$'    
     if [[ $backupOutput =~ $pattern ]]; then

--- a/scripts/deployment/gh_backup.sh
+++ b/scripts/deployment/gh_backup.sh
@@ -16,7 +16,7 @@ source "${current_dir}/../backup/backup_util.sh"
 
 modclub=$(get_canister_name_by_env $ENVIRONMENT "modclub")
 
-backupId_1=$(backup_modclub "stateV2" $DEPLOYMENT_TAG "ic")
+backupId_1=$(backup_modclub "stateV2" $DEPLOYMENT_TAG "ic" $ENVIRONMENT)
 echo "Finished backup: $backupId_1"
 echo "BACKUP_ID_1=${backupId_1}" >> "$GITHUB_ENV"
 echo "BACKUP_FIELDNAME_1=stateV2" >> "$GITHUB_ENV"

--- a/scripts/tests/archive_test/archive_test.sh
+++ b/scripts/tests/archive_test/archive_test.sh
@@ -25,7 +25,7 @@ canister_backup_restore() {
     local data_label=$1
 
     # Perform the backup
-    local backupId=$(backup_modclub $data_label "someTag" local)
+    local backupId=$(backup_modclub $data_label "someTag" local qa)
 
     echo "  ...restore $data_label from Backup:$backupId"
     # Perform the restore

--- a/scripts/tests/archive_test/archive_test.sh
+++ b/scripts/tests/archive_test/archive_test.sh
@@ -3,6 +3,7 @@ set -e
 
 current_dir="$(dirname "$0")"
 source "${current_dir}/../../backup/backup_util.sh"
+source "${current_dir}/../../utils.sh"
 
 check_contains() {
     local string="$1"


### PR DESCRIPTION
### Summary
`scripts/backup/backup_util.sh`was hard-coded the environment setting to QA. 
Introduced a new parameter "env" in the function backup_modclub() to address this issue.

### Issues
[*Link to the issue
](https://linear.app/modclub/issue/MOD-697/backup-process-preventing-deployment-of-prod)
### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

### Checklist
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published.

### Test
*How did you test your change?

### Additional Context
*Add any other context or screenshots about the pull request