### PR TITLE
MOD-698 Refactor secrets engine

### DIFF
--- a/scripts/tests/secrets_test.sh
+++ b/scripts/tests/secrets_test.sh
@@ -34,8 +34,40 @@ check_canister_subscription modclub_qa
 check_canister_subscription vesting_qa
 check_canister_subscription rs_qa
 
+dfx canister call auth_qa removeSecret 'my_secret_1'
+dfx canister call auth_qa removeSecret 'my_secret_2'
+dfx canister call auth_qa removeSecret 'allowed_cg_callers'
+
+principal_1=$(dfx identity get-principal)
+
 dfx canister call auth_qa addSecret '(record { name = "my_secret_1"; value = "abcd" })'
+dfx canister call auth_qa addSecret '(record { name = "my_secret_1"; value = "efgh" })'
 dfx canister call auth_qa addSecret '(record { name = "my_secret_2"; value = "12345" })'
 
-check_auth_secrets my_secret_1 "abcd"
+
+function expected_unauthorized_collectCanisterMetrics_call() {
+    local canister_name=$1
+    local output=$(dfx canister call "$canister_name" collectCanisterMetrics 2>&1) || true
+
+    local expected_error="The replica returned a replica error: Replica Error: reject code CanisterReject, reject message Unauthorized, error code None"
+
+    if [[ "$output" == *"$expected_error"* ]]; then
+        echo "Expected error occurred for $canister_name: $expected_error"
+    else
+        echo "Unexpected result or error for $canister_name: $output"
+        exit 1
+    fi
+}
+
+expected_unauthorized_collectCanisterMetrics_call modclub_qa
+expected_unauthorized_collectCanisterMetrics_call rs_qa
+expected_unauthorized_collectCanisterMetrics_call vesting_qa
+
+dfx canister call auth_qa addSecret "(record { name = \"allowed_cg_callers\"; value = \"$principal_1\" })"
+
+check_auth_secrets my_secret_1 "abcd,efgh"
 check_auth_secrets my_secret_2 "12345"
+
+dfx canister call modclub_qa collectCanisterMetrics
+dfx canister call rs_qa collectCanisterMetrics
+dfx canister call vesting_qa collectCanisterMetrics

--- a/src/authentication/main.mo
+++ b/src/authentication/main.mo
@@ -186,14 +186,14 @@ shared ({ caller = deployer }) actor class ModclubAuth(env : CommonTypes.ENV) = 
   public query ({ caller }) func getCanisterMetrics(
     parameters : Canistergeek.GetMetricsParameters
   ) : async ?Canistergeek.CanisterMetrics {
-    if (not ModSecurity.allowedCanistergeekCaller(caller, authGuard)) {
+    if (not authGuard.allowedCanistergeekCaller(caller)) {
       throw Error.reject("Unauthorized");
     };
     canistergeekMonitor.getMetrics(parameters);
   };
 
   public shared ({ caller }) func collectCanisterMetrics() : async () {
-    if (not ModSecurity.allowedCanistergeekCaller(caller, authGuard)) {
+    if (not authGuard.allowedCanistergeekCaller(caller)) {
       throw Error.reject("Unauthorized");
     };
     canistergeekMonitor.collectMetrics();
@@ -202,7 +202,7 @@ shared ({ caller = deployer }) actor class ModclubAuth(env : CommonTypes.ENV) = 
   public query ({ caller }) func getCanisterLog(
     request : ?LoggerTypesModule.CanisterLogRequest
   ) : async ?LoggerTypesModule.CanisterLogResponse {
-    if (not ModSecurity.allowedCanistergeekCaller(caller, authGuard)) {
+    if (not authGuard.allowedCanistergeekCaller(caller)) {
       throw Error.reject("Unauthorized");
     };
     canistergeekLogger.getLog(request);

--- a/src/common/constants.mo
+++ b/src/common/constants.mo
@@ -44,6 +44,7 @@ module Constants {
 
   public let ACCOUNT_PAYABLE_FIELD = "ACCOUNT_PAYABLE";
 
-  // Secrets prefix
-  public let SECRETS_ALLOWED_CANISTER_GEEK_CALLER = "allowed_cg_caller_";
+  // --- Secrets ----
+  public let SECRET_VALUE_DELIMITER = ',';
+  public let SECRETS_ALLOWED_CANISTER_GEEK_CALLER = "allowed_cg_callers";
 };

--- a/src/common/security/guard.mo
+++ b/src/common/security/guard.mo
@@ -16,24 +16,6 @@ module ModSecurity {
     NotPermitted = "Access denied. No Permissions.";
   };
 
-  public func allowedCanistergeekCaller(caller : Principal, authGuard : ModSecurity.Guard) : Bool {
-    let allowedCallersSecret = authGuard.getSecretVals(Constants.SECRETS_ALLOWED_CANISTER_GEEK_CALLER);
-
-    if (Array.size(allowedCallersSecret) == 0) {
-      return false;
-    };
-
-    let callerStr = Principal.toText(caller);
-
-    var exists = Array.find<Text>(
-      allowedCallersSecret,
-      func(val : Text) : Bool {
-        Text.equal(val, callerStr);
-      }
-    );
-    exists != null;
-  };
-
   public class Guard(env : CommonTypes.ENV, context : Text) {
 
     var admins : List.List<Principal> = List.nil<Principal>();
@@ -180,6 +162,24 @@ module ModSecurity {
 
     public func getEnvs() : CommonTypes.ENV {
       env;
+    };
+
+    public func allowedCanistergeekCaller(caller : Principal) : Bool {
+      let allowedCallersSecret = getSecretVals(Constants.SECRETS_ALLOWED_CANISTER_GEEK_CALLER);
+
+      if (Array.size(allowedCallersSecret) == 0) {
+        return false;
+      };
+
+      let callerStr = Principal.toText(caller);
+
+      var exists = Array.find<Text>(
+        allowedCallersSecret,
+        func(val : Text) : Bool {
+          Text.equal(val, callerStr);
+        }
+      );
+      exists != null;
     };
   };
 };

--- a/src/common/security/guard.mo
+++ b/src/common/security/guard.mo
@@ -8,6 +8,7 @@ import Timer "mo:base/Timer";
 import CommonTypes "../types";
 import Array "mo:base/Array";
 import Constants "../constants";
+import Iter "mo:base/Iter";
 
 module ModSecurity {
 
@@ -16,13 +17,18 @@ module ModSecurity {
   };
 
   public func allowedCanistergeekCaller(caller : Principal, authGuard : ModSecurity.Guard) : Bool {
-    let allowedCallersSecret : [CommonTypes.Secret] = authGuard.getSecrets(Constants.SECRETS_ALLOWED_CANISTER_GEEK_CALLER);
+    let allowedCallersSecret = authGuard.getSecretVals(Constants.SECRETS_ALLOWED_CANISTER_GEEK_CALLER);
+
+    if (Array.size(allowedCallersSecret) == 0) {
+      return false;
+    };
+
     let callerStr = Principal.toText(caller);
 
-    var exists = Array.find<CommonTypes.Secret>(
+    var exists = Array.find<Text>(
       allowedCallersSecret,
-      func(secret : CommonTypes.Secret) : Bool {
-        Text.equal(secret.value, callerStr);
+      func(val : Text) : Bool {
+        Text.equal(val, callerStr);
       }
     );
     exists != null;
@@ -58,14 +64,21 @@ module ModSecurity {
       };
     };
 
-    public func getSecrets(filterName : Text) : [CommonTypes.Secret] {
-      var filterSecrets = List.filter<CommonTypes.Secret>(
-        secrets,
-        func(val : CommonTypes.Secret) : Bool {
-          Text.contains(val.name, #text filterName);
-        }
+    public func getSecretVals(name : Text) : [Text] {
+      let existingSecretOpt = List.find<CommonTypes.Secret>(
+          secrets,
+          func(val : CommonTypes.Secret) : Bool { name == val.name }
       );
-      List.toArray(filterSecrets);
+      switch (existingSecretOpt) {
+          case (?existingSecret) {
+              let delimiter = Constants.SECRET_VALUE_DELIMITER;
+              let parts = Text.split(existingSecret.value, #char delimiter);
+              return Iter.toArray<Text>(parts);
+          };
+          case null {
+              return [];
+          };
+      };
     };
 
     public func getAdmins() : [Principal] {

--- a/src/modclub/main.mo
+++ b/src/modclub/main.mo
@@ -1944,14 +1944,14 @@ shared ({ caller = deployer }) actor class ModClub(env : CommonTypes.ENV) = this
   public query ({ caller }) func getCanisterMetrics(
     parameters : Canistergeek.GetMetricsParameters
   ) : async ?Canistergeek.CanisterMetrics {
-    if (not ModSecurity.allowedCanistergeekCaller(caller, authGuard)) {
+    if (not authGuard.allowedCanistergeekCaller(caller)) {
       throw Error.reject("Unauthorized");
     };
     canistergeekMonitor.getMetrics(parameters);
   };
 
   public shared ({ caller }) func collectCanisterMetrics() : async () {
-    if (not ModSecurity.allowedCanistergeekCaller(caller, authGuard)) {
+    if (not authGuard.allowedCanistergeekCaller(caller)) {
       throw Error.reject("Unauthorized");
     };
     canistergeekMonitor.collectMetrics();
@@ -1960,7 +1960,7 @@ shared ({ caller = deployer }) actor class ModClub(env : CommonTypes.ENV) = this
   public query ({ caller }) func getCanisterLog(
     request : ?LoggerTypesModule.CanisterLogRequest
   ) : async ?LoggerTypesModule.CanisterLogResponse {
-    if (not ModSecurity.allowedCanistergeekCaller(caller, authGuard)) {
+    if (not authGuard.allowedCanistergeekCaller(caller)) {
       throw Error.reject("Unauthorized");
     };
     logger.logMessage("getCanisterLog - request from caller: " # Principal.toText(caller));

--- a/src/modclub/service/storage/buckets.mo
+++ b/src/modclub/service/storage/buckets.mo
@@ -415,14 +415,14 @@ shared ({ caller = deployer }) actor class Bucket(env : CommonTypes.ENV) = this 
   public query ({ caller }) func getCanisterMetrics(
     parameters : Canistergeek.GetMetricsParameters
   ) : async ?Canistergeek.CanisterMetrics {
-    if (not ModSecurity.allowedCanistergeekCaller(caller, authGuard)) {
+    if (not authGuard.allowedCanistergeekCaller(caller)) {
       throw Error.reject("Unauthorized");
     };
     canistergeekMonitor.getMetrics(parameters);
   };
 
   public shared ({ caller }) func collectCanisterMetrics() : async () {
-    if (not ModSecurity.allowedCanistergeekCaller(caller, authGuard)) {
+    if (not authGuard.allowedCanistergeekCaller(caller)) {
       throw Error.reject("Unauthorized");
     };
     canistergeekMonitor.collectMetrics();
@@ -431,7 +431,7 @@ shared ({ caller = deployer }) actor class Bucket(env : CommonTypes.ENV) = this 
   public query ({ caller }) func getCanisterLog(
     request : ?LoggerTypesModule.CanisterLogRequest
   ) : async ?LoggerTypesModule.CanisterLogResponse {
-    if (not ModSecurity.allowedCanistergeekCaller(caller, authGuard)) {
+    if (not authGuard.allowedCanistergeekCaller(caller)) {
       throw Error.reject("Unauthorized");
     };
     canistergeekLogger.getLog(request);

--- a/src/rs/main.mo
+++ b/src/rs/main.mo
@@ -145,14 +145,14 @@ shared ({ caller = deployer }) actor class RSManager(env : CommonTypes.ENV) = th
   public query ({ caller }) func getCanisterMetrics(
     parameters : Canistergeek.GetMetricsParameters
   ) : async ?Canistergeek.CanisterMetrics {
-    if (not ModSecurity.allowedCanistergeekCaller(caller, authGuard)) {
+    if (not authGuard.allowedCanistergeekCaller(caller)) {
       throw Error.reject("Unauthorized");
     };
     canistergeekMonitor.getMetrics(parameters);
   };
 
   public shared ({ caller }) func collectCanisterMetrics() : async () {
-    if (not ModSecurity.allowedCanistergeekCaller(caller, authGuard)) {
+    if (not authGuard.allowedCanistergeekCaller(caller)) {
       throw Error.reject("Unauthorized");
     };
     canistergeekMonitor.collectMetrics();
@@ -161,7 +161,7 @@ shared ({ caller = deployer }) actor class RSManager(env : CommonTypes.ENV) = th
   public query ({ caller }) func getCanisterLog(
     request : ?LoggerTypesModule.CanisterLogRequest
   ) : async ?LoggerTypesModule.CanisterLogResponse {
-    if (not ModSecurity.allowedCanistergeekCaller(caller, authGuard)) {
+    if (not authGuard.allowedCanistergeekCaller(caller)) {
       throw Error.reject("Unauthorized");
     };
     canistergeekLogger.getLog(request);

--- a/src/vesting/main.mo
+++ b/src/vesting/main.mo
@@ -144,14 +144,14 @@ shared ({ caller = deployer }) actor class Vesting(env : CommonTypes.ENV) = this
   public query ({ caller }) func getCanisterMetrics(
     parameters : Canistergeek.GetMetricsParameters
   ) : async ?Canistergeek.CanisterMetrics {
-    if (not ModSecurity.allowedCanistergeekCaller(caller, authGuard)) {
+    if (not authGuard.allowedCanistergeekCaller(caller)) {
       throw Error.reject("Unauthorized");
     };
     canistergeekMonitor.getMetrics(parameters);
   };
 
   public shared ({ caller }) func collectCanisterMetrics() : async () {
-    if (not ModSecurity.allowedCanistergeekCaller(caller, authGuard)) {
+    if (not authGuard.allowedCanistergeekCaller(caller)) {
       throw Error.reject("Unauthorized");
     };
     canistergeekMonitor.collectMetrics();
@@ -160,7 +160,7 @@ shared ({ caller = deployer }) actor class Vesting(env : CommonTypes.ENV) = this
   public query ({ caller }) func getCanisterLog(
     request : ?LoggerTypesModule.CanisterLogRequest
   ) : async ?LoggerTypesModule.CanisterLogResponse {
-    if (not ModSecurity.allowedCanistergeekCaller(caller, authGuard)) {
+    if (not authGuard.allowedCanistergeekCaller(caller)) {
       throw Error.reject("Unauthorized");
     };
     canistergeekLogger.getLog(request);


### PR DESCRIPTION
---
### Summary
- Each secret name corresponds to a list of secret values, which are separated by commas.
- Move allowedCanistergeekCaller to guard
### Issues
*Link to the issue

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

### Checklist
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published.

### Test
*How did you test your change?

### Additional Context
*Add any other context or screenshots about the pull request