### PR TITLE
Proposal-Cost-Change-Final

### DIFF
--- a/scripts/sns/install/upgrade_dapp.sh
+++ b/scripts/sns/install/upgrade_dapp.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# This script is used to create an SNS proposal for increasing the cost of proposal rejection to 200 MOD
+# This script is called by upgrade_test_canister.sh (please update the name when deploying on prod, replace test with the desired name)
+# For detailed explanation please see the GitHub Repo: https://github.com/dfinity/sns-testing/tree/main
+
+
+set -euo pipefail
+
+CURRENTDIR="$(pwd)"
+
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")"
+
+REPODIR="$(pwd)"
+# below parameters passed by upgrade_test_canister.sh
+export NAME="${1:-test}" # Name of the target canister or will be default to test
+export WASM="${2:-}" # Path to the new WASM module for the upgrade
+export ARG="${3:-()}" # Additional parameters or payload for the operation, formatted as required (often in Candid syntax)
+
+. ./constants.sh normal
+
+export DEVELOPER_NEURON_ID="$(dfx canister \
+  --network "${NETWORK}" \
+  call "${SNS_GOVERNANCE_CANISTER_ID}" \
+  --candid candid/sns_governance.did \
+  list_neurons "(record {of_principal = opt principal\"${DX_PRINCIPAL}\"; limit = 1})" \
+    | idl2json \
+    | jq -r ".neurons[0].id[0].id" \
+    | python3 -c "import sys; ints=sys.stdin.readlines(); sys.stdout.write(bytearray(eval(''.join(ints))).hex())")"
+
+cd "${CURRENTDIR}"
+
+if [ -f "${ARG}" ]
+then
+  ARGFLAG="--canister-upgrade-arg-path"
+else
+  ARGFLAG="--canister-upgrade-arg"
+fi
+
+if [[ -z "${WASM}" ]]
+then
+  dfx build --network "${NETWORK}" "${NAME}"
+  export WASM=".dfx/${DX_NETWORK}/canisters/${NAME}/${NAME}.wasm"
+fi
+
+export CID="$(dfx canister --network "${NETWORK}" id "${NAME}")"
+quill sns  \
+   --canister-ids-file "${REPODIR}/sns_canister_ids.json"  \
+   --pem-file "${PEM_FILE}"  \
+   make-upgrade-canister-proposal  \
+   --summary "SNS Proposal for Increasing the Cost of Proposal Rejection to 200 MOD"  \
+   --title "SNS Proposal for Changing Proposal Rejection Cost"  \
+   --url "https://example.com/"  \
+   --target-canister-id "${CID}"  \
+   --wasm-path "${WASM}"  \
+   "${ARGFLAG}" "${ARG}"  \
+   "${DEVELOPER_NEURON_ID}" > msg.json
+quill send \
+  --insecure-local-dev-mode \
+  --yes msg.json | grep -v "new_canister_wasm"

--- a/scripts/sns/install/upgrade_test_canister.sh
+++ b/scripts/sns/install/upgrade_test_canister.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# For detailed explanation please see the GitHub Repo: https://github.com/dfinity/sns-testing/tree/main
+
+set -euo pipefail
+
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")"
+
+#The test canister (to be replaced with modclub canister or a specific one to be decentralized), as mentioned in README.md, keeps a greeting message along with an integer counter. It exposes public methods to get the value of the counter and a greeting text that starts with the greeting message. This suggests that GREETING is used as a part of the canister's state or output.
+
+GREETING="${1:-Hoi}" # Greeting to be used in the proposal, if no greeting message set default is 'Hoi'.
+
+. ./constants.sh normal
+
+if [ -f "./sns_canister_ids.json" ]
+then
+    ./upgrade_dapp.sh "test" "" "(opt record {sns_governance = opt principal\"${SNS_GOVERNANCE_CANISTER_ID}\"; greeting = opt \"${GREETING}\";})"
+else
+    ./upgrade_dapp.sh "test" "" "(opt record {sns_governance = null; greeting = opt \"${GREETING}\";})"
+fi


### PR DESCRIPTION
---
### Summary
* Added 2 scripts to create an SNS proposal to increase the rejection cost of a proposal to 200 MOD. upgrade_test_canister.sh should be used to initiate the process then it calls upgrade_dapp.sh which has the main logic for the proposal. 2 scripts have been used for simplicity. Left comments in the code about how to replace test canister with the real one when switching to production. This scenario is a very isolated one, for production all of the scripts and files .json, .yml etc.) related to SNS should be reviewed and updated according to the current Dfinity SNS setup published.  

### Issues (MOD-694)
*https://linear.app/modclub/issue/MOD-694/sns-proposal-to-increase-the-rejection-cost

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

### Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published.

### Test
* How did you test your change? 
Used the Dfinity provided sns testing repo link below:
https://github.com/dfinity/sns-testing/tree/main

### Additional Context
<img width="1258" alt="Screen Shot 2024-01-28 at 9 46 46 PM" src="https://github.com/modclub-app/modclub_src/assets/82664734/4043d95d-5d09-4c12-a37c-a62e5472a7c4">

<img width="1258" alt="Screen Shot 2024-01-28 at 9 24 09 PM" src="https://github.com/modclub-app/modclub_src/assets/82664734/3c50fc5c-f11c-433a-80e0-5c033621a5ae">




