### PR TITLE
Mod 627 bucket extra timer

### DIFF
--- a/src/modclub/service/storage/buckets.mo
+++ b/src/modclub/service/storage/buckets.mo
@@ -609,10 +609,6 @@ shared ({ caller = deployer }) actor class Bucket(env : CommonTypes.ENV) = this 
         case (?tid) { Timer.cancelTimer(tid) };
         case (null) {};
       };
-      // switch (canistergeekTimer) {
-      //   case (?tid) { Timer.cancelTimer(tid) };
-      //   case (null) {};
-      // };
       canistergeekTimer := ?Timer.recurringTimer(
         #nanoseconds(Constants.ONE_HOUR_NANO_SECS),
         func() : async () { canistergeekMonitor.collectMetrics() }
@@ -653,6 +649,7 @@ shared ({ caller = deployer }) actor class Bucket(env : CommonTypes.ENV) = this 
     _canistergeekLoggerUD := null;
     canistergeekLogger.setMaxMessagesCount(3000);
 
+    //second timer is to ensure that the timer is set again after upgrade
     ignore Timer.setTimer(
       #seconds 0,
       func() : async () {
@@ -661,10 +658,6 @@ shared ({ caller = deployer }) actor class Bucket(env : CommonTypes.ENV) = this 
           case (?tid) { Timer.cancelTimer(tid) };
           case (null) {};
         };
-        // switch (canistergeekTimer) {
-        //   case (?tid) { Timer.cancelTimer(tid) };
-        //   case (null) {};
-        // };
         canistergeekTimer := ?Timer.recurringTimer(
           #nanoseconds(Constants.ONE_HOUR_NANO_SECS),
           func() : async () { canistergeekMonitor.collectMetrics() }

--- a/src/modclub/service/storage/buckets.mo
+++ b/src/modclub/service/storage/buckets.mo
@@ -381,7 +381,7 @@ shared ({ caller = deployer }) actor class Bucket(env : CommonTypes.ENV) = this 
           ("Content-Disposition", "inline")
         ];
         _status_code := 200;
-        _streaming_strategy := ?#Callback(
+        _streaming_strategy := ? #Callback(
           {
             token = {
               content_encoding = "gzip";
@@ -609,10 +609,10 @@ shared ({ caller = deployer }) actor class Bucket(env : CommonTypes.ENV) = this 
         case (?tid) { Timer.cancelTimer(tid) };
         case (null) {};
       };
-      switch (canistergeekTimer) {
-        case (?tid) { Timer.cancelTimer(tid) };
-        case (null) {};
-      };
+      // switch (canistergeekTimer) {
+      //   case (?tid) { Timer.cancelTimer(tid) };
+      //   case (null) {};
+      // };
       canistergeekTimer := ?Timer.recurringTimer(
         #nanoseconds(Constants.ONE_HOUR_NANO_SECS),
         func() : async () { canistergeekMonitor.collectMetrics() }
@@ -661,10 +661,10 @@ shared ({ caller = deployer }) actor class Bucket(env : CommonTypes.ENV) = this 
           case (?tid) { Timer.cancelTimer(tid) };
           case (null) {};
         };
-        switch (canistergeekTimer) {
-          case (?tid) { Timer.cancelTimer(tid) };
-          case (null) {};
-        };
+        // switch (canistergeekTimer) {
+        //   case (?tid) { Timer.cancelTimer(tid) };
+        //   case (null) {};
+        // };
         canistergeekTimer := ?Timer.recurringTimer(
           #nanoseconds(Constants.ONE_HOUR_NANO_SECS),
           func() : async () { canistergeekMonitor.collectMetrics() }

--- a/src/modclub/service/storage/buckets.mo
+++ b/src/modclub/service/storage/buckets.mo
@@ -381,7 +381,7 @@ shared ({ caller = deployer }) actor class Bucket(env : CommonTypes.ENV) = this 
           ("Content-Disposition", "inline")
         ];
         _status_code := 200;
-        _streaming_strategy := ? #Callback(
+        _streaming_strategy := ?#Callback(
           {
             token = {
               content_encoding = "gzip";

--- a/src/modclub/service/storage/buckets.mo
+++ b/src/modclub/service/storage/buckets.mo
@@ -611,7 +611,10 @@ shared ({ caller = deployer }) actor class Bucket(env : CommonTypes.ENV) = this 
       };
       canistergeekTimer := ?Timer.recurringTimer(
         #nanoseconds(Constants.ONE_HOUR_NANO_SECS),
-        func() : async () { canistergeekMonitor.collectMetrics() }
+        func() : async () {
+          Helpers.logMessage(canistergeekLogger, "Running Collecting Metrics job.", #info);
+          canistergeekMonitor.collectMetrics();
+        }
       );
       deleteContentTimer := ?Timer.recurringTimer(
         #nanoseconds(Constants.TWENTY_FOUR_HOUR_NANO_SECS),
@@ -649,28 +652,6 @@ shared ({ caller = deployer }) actor class Bucket(env : CommonTypes.ENV) = this 
     _canistergeekLoggerUD := null;
     canistergeekLogger.setMaxMessagesCount(3000);
 
-    //second timer is to ensure that the timer is set again after upgrade
-    ignore Timer.setTimer(
-      #seconds 0,
-      func() : async () {
-        canistergeekMonitor.collectMetrics();
-        switch (canistergeekTimer) {
-          case (?tid) { Timer.cancelTimer(tid) };
-          case (null) {};
-        };
-        canistergeekTimer := ?Timer.recurringTimer(
-          #nanoseconds(Constants.ONE_HOUR_NANO_SECS),
-          func() : async () { canistergeekMonitor.collectMetrics() }
-        );
-        deleteContentTimer := ?Timer.recurringTimer(
-          #nanoseconds(Constants.TWENTY_FOUR_HOUR_NANO_SECS),
-          func() : async () {
-            Helpers.logMessage(canistergeekLogger, "Running Delete ContentId job.", #info);
-            deleteContentAfterExpiry();
-          }
-        );
-      }
-    );
   };
 
   system func inspect({


### PR DESCRIPTION
---
### Summary
* Implemented some logs inside the timer code to see the outputs, then run the upgrade_bucket.sh script, timers were working. Then, deleted the second timer which was inside the ‘system func postupgrade() {}’ and then run the script again to see the difference, the single timer was still doing the same job such as  setting up timer, deleting content and collecting metrics. Which means the timer inside the ‘system func postupgrade() {}’ is unnecessary. 

* Also there was a duplicated switch statement inside the timer, omitted one of it.

I used this canister for candid  Backend canister via Candid interface:
    l_bucket_0: http://127.0.0.1:8080/?canisterId=aax3a-h4aaa-aaaaa-qaahq-cai&id=ahw5u-keaaa-aaaaa-qaaha-cai

### Issues
*https://linear.app/modclub/issue/MOD-627/bucket-code-has-two-delete-timers

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Code cleaning 

### Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published.

### Test
*How did you test your change?
Using Candid UI

### Additional Context
*Image below is the output of single timer after running the upgrade_buckets.sh script.

<img width="1335" alt="Screen Shot 2024-02-03 at 2 15 26 PM" src="https://github.com/modclub-app/modclub_src/assets/82664734/5fd6e7f8-dcc9-407b-9b5c-6cbfe2c78d23">
 
