### PR TITLE
MOD-713 Account registration

### DIFF
--- a/scripts/tests/decideid_test/sanity_test.sh
+++ b/scripts/tests/decideid_test/sanity_test.sh
@@ -6,3 +6,10 @@ source "${current_dir}/../../utils.sh"
 
 dfx identity use default
 dfx canister call decideid_qa hello
+
+output=$(dfx canister call decideid_qa registerAccount '("John", "Doe", "john.doe@example.com")')
+echo "$output"
+id=$(echo "$output" | awk -F'"' '/ok =/{print $(NF-1)}')
+echo "Created decide id: $id"
+dfx canister call decideid_qa getAccount "(\"$id\")"
+

--- a/src/common/types.mo
+++ b/src/common/types.mo
@@ -18,7 +18,7 @@ module {
     decideid_canister_id : Principal;
   };
 
-  public type Timestamp = Nat;
+  public type Timestamp = Int;
 
   public type VestingCanisterActor = actor {
     stake : (ICRCTypes.Account, ICRCTypes.Tokens) -> async Result.Result<Nat, Text>;

--- a/src/common/types.mo
+++ b/src/common/types.mo
@@ -18,6 +18,8 @@ module {
     decideid_canister_id : Principal;
   };
 
+  public type Timestamp = Int;
+
   public type VestingCanisterActor = actor {
     stake : (ICRCTypes.Account, ICRCTypes.Tokens) -> async Result.Result<Nat, Text>;
     claim_staking : (ICRCTypes.Account, ICRCTypes.Tokens) -> async Result.Result<Nat, Text>;

--- a/src/common/types.mo
+++ b/src/common/types.mo
@@ -18,7 +18,7 @@ module {
     decideid_canister_id : Principal;
   };
 
-  public type Timestamp = Int;
+  public type Timestamp = Nat;
 
   public type VestingCanisterActor = actor {
     stake : (ICRCTypes.Account, ICRCTypes.Tokens) -> async Result.Result<Nat, Text>;

--- a/src/decideid/inspectTypes.mo
+++ b/src/decideid/inspectTypes.mo
@@ -1,6 +1,7 @@
 import LoggerTypesModule "../common/canistergeek/logger/typesModule";
 import Canistergeek "../common/canistergeek/canistergeek";
 import CommonTypes "../common/types";
+import Types "types";
 
 module {
   public type DecideIdCanisterMethods = {
@@ -9,6 +10,8 @@ module {
     #getCanisterLog : () -> ?LoggerTypesModule.CanisterLogRequest;
     #getCanisterMetrics : () -> Canistergeek.GetMetricsParameters;
     #hello : () -> ();
+    #getAccount : () -> Types.DecideID;
+    #registerAccount : () -> (Text, Text, Text);
 
   }
 }

--- a/src/decideid/inspectTypes.mo
+++ b/src/decideid/inspectTypes.mo
@@ -11,6 +11,7 @@ module {
     #getCanisterMetrics : () -> Canistergeek.GetMetricsParameters;
     #hello : () -> ();
     #getAccount : () -> Types.DecideID;
+    #getAccByCaller : () -> ();
     #registerAccount : () -> (Text, Text, Text);
 
   }

--- a/src/decideid/main.mo
+++ b/src/decideid/main.mo
@@ -112,6 +112,18 @@ shared ({ caller = deployer }) actor class DecideID(env : CommonTypes.ENV) = thi
 
     // TODO: registerFromThirdParty()
 
+    public shared ({ caller }) func getAccByCaller(
+    ) : async Result.Result<Types.GetAccountResponse, Text> {
+        switch (principal2decideid.get(caller)) {
+        case (null) {
+          return #err("Not registered.");
+        };
+        case (?decideid) {
+          // User already registered
+          await accountManager.get(decideid);
+        };
+      };        
+    };
 
     public shared ({ caller }) func getAccount(
         decideid: Types.DecideID

--- a/src/decideid/service/account/account.mo
+++ b/src/decideid/service/account/account.mo
@@ -1,0 +1,66 @@
+import Map "mo:base/HashMap";
+import Principal "mo:base/Principal";
+import Types "../../types";
+import Result "mo:base/Result";
+import Utils "../../utils";
+import Helpers "../../../common/helpers";
+
+module Account {
+
+  public class AccountManager(
+    accounts: Map.HashMap<Types.DecideID, Types.Account>,
+    principal2accounts: Map.HashMap<Principal, Types.DecideID>
+  ) {
+    public func register(
+      caller: Principal,
+      accUserPrincipal: Principal,
+      firstName: Text,
+      lastName: Text, 
+      email: Text
+    ) : async Result.Result<Types.DecideID, Text> {
+      // Check if the user has already registered
+      switch (principal2accounts.get(accUserPrincipal)) {
+        case (null) {
+          // User not registered, proceed with registration
+          
+          let newDecideID = await Utils.generateUUID();
+          
+          // Add the new account
+          let newAcc: Types.Account = {
+            id = newDecideID;
+            principal = accUserPrincipal;
+            acc_type = #organic; 
+            state = #onboarding; 
+            onboardingCompletedSteps = [#basic];
+            createdAt = Helpers.timeNow();
+            updatedAt = Helpers.timeNow();
+            createdBy = caller;
+          };
+          accounts.put(newDecideID, newAcc);
+          principal2accounts.put(accUserPrincipal, newDecideID);
+          return #ok(newDecideID);
+
+        };
+        case (_) {
+          // User already registered
+          return #err("Pricipal " # Principal.toText(accUserPrincipal) # "already registered.");
+        };
+      };
+    };
+
+    public func get(
+      decideid: Types.DecideID
+    ) : async Result.Result<Types.Account, Text> {
+      switch (accounts.get(decideid)) {
+        case (null) {
+          return #err("Cannot find account");
+        };
+        case (?account) {
+          return #ok(account);
+        };
+      };
+    }
+
+  }
+
+};

--- a/src/decideid/service/account/account.mo
+++ b/src/decideid/service/account/account.mo
@@ -9,7 +9,7 @@ module Account {
 
   public class AccountManager(
     accounts: Map.HashMap<Types.DecideID, Types.Account>,
-    principal2accounts: Map.HashMap<Principal, Types.DecideID>,
+    principal2decide: Map.HashMap<Principal, Types.DecideID>,
     profiles: Map.HashMap<Types.DecideID, Types.Profile>
   ) {
     public func register(
@@ -20,7 +20,7 @@ module Account {
       email: Text
     ) : async Result.Result<Types.DecideID, Text> {
       // Check if the user has already registered
-      switch (principal2accounts.get(accUserPrincipal)) {
+      switch (principal2decide.get(accUserPrincipal)) {
         case (null) {
           // User not registered, proceed with registration
           
@@ -38,7 +38,7 @@ module Account {
             createdBy = caller;
           };
           accounts.put(newDecideID, newAcc);
-          principal2accounts.put(accUserPrincipal, newDecideID);
+          principal2decide.put(accUserPrincipal, newDecideID);
           profiles.put(newDecideID, {
             firstName = firstName;
             lastName = lastName;

--- a/src/decideid/service/account/account.mo
+++ b/src/decideid/service/account/account.mo
@@ -1,15 +1,16 @@
 import Map "mo:base/HashMap";
 import Principal "mo:base/Principal";
-import Types "../../types";
 import Result "mo:base/Result";
 import Utils "../../utils";
 import Helpers "../../../common/helpers";
+import Types "./types";
 
 module Account {
 
   public class AccountManager(
     accounts: Map.HashMap<Types.DecideID, Types.Account>,
-    principal2accounts: Map.HashMap<Principal, Types.DecideID>
+    principal2accounts: Map.HashMap<Principal, Types.DecideID>,
+    profiles: Map.HashMap<Types.DecideID, Types.Profile>
   ) {
     public func register(
       caller: Principal,
@@ -38,6 +39,11 @@ module Account {
           };
           accounts.put(newDecideID, newAcc);
           principal2accounts.put(accUserPrincipal, newDecideID);
+          profiles.put(newDecideID, {
+            firstName = firstName;
+            lastName = lastName;
+            email = ?email;
+          });
           return #ok(newDecideID);
 
         };
@@ -50,13 +56,23 @@ module Account {
 
     public func get(
       decideid: Types.DecideID
-    ) : async Result.Result<Types.Account, Text> {
+    ) : async Result.Result<Types.GetAccountResponse, Text> {
       switch (accounts.get(decideid)) {
         case (null) {
           return #err("Cannot find account");
         };
         case (?account) {
-          return #ok(account);
+          switch (profiles.get(decideid)) {
+            case (null) {
+              return #err("Cannot find profile");
+            };
+            case (?profile) {
+              return #ok({
+                acc=account;
+                profile=profile
+              });
+            };
+          }
         };
       };
     }

--- a/src/decideid/service/account/types.mo
+++ b/src/decideid/service/account/types.mo
@@ -1,0 +1,56 @@
+import Result "mo:base/Result";
+import List "mo:base/List";
+import Bool "mo:base/Bool";
+import Text "mo:base/Text";
+import Nat "mo:base/Nat";
+import Nat8 "mo:base/Nat8";
+import Float "mo:base/Float";
+import Principal "mo:base/Principal";
+import CommonTypes "../../../common/types";
+
+module {
+    public type DecideID = Text;
+    public type AccountType = {
+        #organic;
+        #third_party;
+    };
+
+    public type AccountState = {
+        // Represents the lifecycle stages of an account.
+
+        #onboarding;   // The initial stage where users are prompted to submit their information for account setup.
+        #review;       // At this stage, submissions are under review for duplications and verification of authenticity (PoH).
+        #approved;     // Indicates the account has passed review and is now fully active and operational.
+        #rejected;     // Signifies the account did not meet the necessary criteria during the review and has been denied access.
+    };
+
+    public type OnboardingStep = {
+        #basic;
+        #pohVideo;
+    };
+
+    public type Profile = {
+        firstName: Text;
+        lastName: Text;
+        email:?Text;
+    };
+
+    public type Account = {
+        id: Text;                // decide id
+        principal: Principal;    // user's principal
+
+        acc_type: AccountType;
+        state: AccountState;
+
+        onboardingCompletedSteps: [OnboardingStep];
+
+        createdAt: CommonTypes.Timestamp;
+        updatedAt: CommonTypes.Timestamp;
+        createdBy: Principal;
+    };
+
+    public type GetAccountResponse = {
+        acc: Account;
+        profile: Profile;
+    }
+}

--- a/src/decideid/types.mo
+++ b/src/decideid/types.mo
@@ -7,41 +7,11 @@ import Nat8 "mo:base/Nat8";
 import Float "mo:base/Float";
 import Principal "mo:base/Principal";
 import CommonTypes "../common/types";
-
+import AccountTypes "./service/account/types";
 module {
-  public type DecideID = Text;
-
-  public type AccountType = {
-    #organic;
-    #third_party;
-  };
-
-  public type AccountState = {
-    // Represents the lifecycle stages of an account.
-
-    #onboarding;   // The initial stage where users are prompted to submit their information for account setup.
-    #review;       // At this stage, submissions are under review for duplications and verification of authenticity (PoH).
-    #approved;     // Indicates the account has passed review and is now fully active and operational.
-    #rejected;     // Signifies the account did not meet the necessary criteria during the review and has been denied access.
-  };
-
-   public type OnboardingStep = {
-     #basic;
-     #pohVideo;
-   };
-
-  public type Account = {
-    id: Text;                // decide id
-    principal: Principal;    // user's principal
-
-    acc_type: AccountType;
-    state: AccountState;
-
-    onboardingCompletedSteps: [OnboardingStep];
-
-    createdAt: CommonTypes.Timestamp;
-    updatedAt: CommonTypes.Timestamp;
-    createdBy: Principal;
-  };
+  public type Account=AccountTypes.Account;
+  public type Profile=AccountTypes.Profile;
+  public type DecideID=AccountTypes.DecideID;
+  public type GetAccountResponse=AccountTypes.GetAccountResponse;
 
 };

--- a/src/decideid/types.mo
+++ b/src/decideid/types.mo
@@ -1,0 +1,46 @@
+import Result "mo:base/Result";
+import List "mo:base/List";
+import Bool "mo:base/Bool";
+import Text "mo:base/Text";
+import Nat "mo:base/Nat";
+import Nat8 "mo:base/Nat8";
+import Float "mo:base/Float";
+import Principal "mo:base/Principal";
+import CommonTypes "../common/types";
+
+module {
+  public type DecideID = Text;
+
+  public type AccountType = {
+    #organic;  
+    #third_party;
+  };
+
+  public type AccountState = {
+    // represents the lifecycle of an account
+    #onboarding;   // during onboarding, asking users to submit different information
+    #review;       // during review, we will check dup and humananity 
+    #approved;     // finall
+    #rejected;
+  };
+
+   public type OnboardingStep = {
+     #basic;
+     #pohVideo;
+   };
+
+  public type Account = {
+    id: Text;                // decide id
+    principal: Principal;    // user's principal
+
+    acc_type: AccountType;
+    state: AccountState;
+
+    onboardingCompletedSteps: [OnboardingStep];
+
+    createdAt: CommonTypes.Timestamp;
+    updatedAt: CommonTypes.Timestamp;
+    createdBy: Principal;
+  };
+
+};

--- a/src/decideid/types.mo
+++ b/src/decideid/types.mo
@@ -12,16 +12,17 @@ module {
   public type DecideID = Text;
 
   public type AccountType = {
-    #organic;  
+    #organic;
     #third_party;
   };
 
   public type AccountState = {
-    // represents the lifecycle of an account
-    #onboarding;   // during onboarding, asking users to submit different information
-    #review;       // during review, we will check dup and humananity 
-    #approved;     // finall
-    #rejected;
+    // Represents the lifecycle stages of an account.
+
+    #onboarding;   // The initial stage where users are prompted to submit their information for account setup.
+    #review;       // At this stage, submissions are under review for duplications and verification of authenticity (PoH).
+    #approved;     // Indicates the account has passed review and is now fully active and operational.
+    #rejected;     // Signifies the account did not meet the necessary criteria during the review and has been denied access.
   };
 
    public type OnboardingStep = {

--- a/src/decideid/utils.mo
+++ b/src/decideid/utils.mo
@@ -1,0 +1,10 @@
+import Source "mo:uuid/async/SourceV4";
+import UUID "mo:uuid/UUID";
+
+module {
+    public func generateUUID() : async Text {
+        let g = Source.Source();
+        let uuid = await g.new();
+        return UUID.toText(await g.new());
+    };
+}


### PR DESCRIPTION
---
# Summary
Implemented basic functionality to register a new account.

## APIs
### registerAccount()
```
public shared ({ caller }) func registerAccount(  
      firstName: Text,
      lastName: Text, 
      email: Text
    ) : async Result.Result<Types.DecideID, Text> 
```

### getAccount()
```
public shared ({ caller }) func getAccount(
        decideid: Types.DecideID
    ) : async Result.Result<Types.GetAccountResponse, Text>

public type GetAccountResponse = {
    acc: Account;
    profile: Profile;
}
```

## Storage
Introduced two storages respectively:
- `accounts`: stores the basic metadata of an account
- `profiles`: stores the profile of a user

Note that each storage is using decideid as the primary key. There is another lookup table `principal2decideid` to help mapping user's principal id to decide id


### Issues
*Link to the issue

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

### Checklist
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published.

### Test
*How did you test your change?

### Additional Context
*Add any other context or screenshots about the pull request