### PR TITLE
[DONT merge, TESTING PURPOSE] Revert "MOD-1003 use normal deploy for auth canister" 

### DIFF
--- a/.github/workflows/deploy_qa.yml
+++ b/.github/workflows/deploy_qa.yml
@@ -42,12 +42,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Exit if the branch is not main
-        run: |
-          if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
-            echo "Branch is not main, exiting."
-            exit 1
-          fi
+      # - name: Exit if the branch is not main
+      #   run: |
+      #     if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
+      #       echo "Branch is not main, exiting."
+      #       exit 1
+      #     fi
 
       - name: Set Node.js 18.x
         uses: actions/setup-node@v3

--- a/scripts/deployment/deployment_utils.sh
+++ b/scripts/deployment/deployment_utils.sh
@@ -1,33 +1,6 @@
 #!/bin/bash
 set -e
 
-standard_deploy() {
-  local canister_name=$1
-  local network=$2
-  local env_vars=$3
-
-  echo "Creating canister ${canister_name}..."
-  dfx canister create ${canister_name}
-
-  echo "Building ${canister_name}..."
-  dfx build ${canister_name}
-
-  echo "Deploying ${canister_name}..."
-
-  echo "Env vars ${env_vars}"
-
-  local cmd="dfx deploy ${canister_name} --network=${network} --argument=${env_vars}"
-
-  if [[ $BYPASS_PROMPT_YES == "yes" || $BYPASS_PROMPT_YES == "Yes" || $BYPASS_PROMPT_YES == "YES" ]]; then
-      cmd+=" --yes"
-  fi
-
-  eval $cmd &&
-  echo "[DEPLOY] Canister ${canister_name} deployed successfully." && return 0;
-  
-  echo "[ERROR] Unable to deploy ${canister_name}" && exit 1
-}
-
 gzip_and_deploy() {
   local canister_name=$1
   local network=$2
@@ -102,7 +75,7 @@ function deploy_canisters() {
   elif [ "$canister_only" = "modclub" ]; then
     gzip_and_deploy $modclub_canister_name $network "'(${env_vars})'" $mode
   elif [ "$canister_only" = "auth" ]; then
-    standard_deploy $auth_canister_name $network "'(${env_vars})'"
+    gzip_and_deploy $auth_canister_name $network "'(${env_vars})'" $mode
   elif [ "$canister_only" = "wallet" ]; then
     deploy_wallet_canister $env $network $ledger_minter_identity $ledger_account_identity
   elif [ "$canister_only" = "vesting" ]; then
@@ -115,7 +88,7 @@ function deploy_canisters() {
     set -x
     set -e
     log "Deploy ${env} Canisters..."
-    standard_deploy $auth_canister_name $network "'(${env_vars})'" &&
+    gzip_and_deploy $auth_canister_name $network "'(${env_vars})'" $mode &&
     deploy_wallet_canister $env $network $ledger_minter_identity $ledger_account_identity &&
     deploy_vesting_canister $env $network $old_modclub_inst &&
     gzip_and_deploy $airdrop_canister_name $network "'(${env_vars})'" $mode &&  


### PR DESCRIPTION
Reverts modclub-app/modclub_src#84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated deployment script to use `gzip_and_deploy` function for specific canister deployments.
  - Disabled branch validation step in the QA deployment workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->